### PR TITLE
Add explicit cast for parsing fpcalc output

### DIFF
--- a/acoustid.py
+++ b/acoustid.py
@@ -300,7 +300,7 @@ def _fingerprint_file_fpcalc(path, maxlength):
             raise FingerprintGenerationError("malformed fpcalc output")
         if parts[0] == b'DURATION':
             try:
-                duration = int(parts[1])
+                duration = int(float(parts[1]))
             except ValueError:
                 raise FingerprintGenerationError("fpcalc duration not numeric")
         elif parts[0] == b'FINGERPRINT':


### PR DESCRIPTION
Add a cast to float when reading the DURATION field from the output of fpcalc to fix an error with pyacoustid failing (when running on cygwin).

On my system, the fpcalc outputs the duration as a decimal value.  Python could not read that into an int and was throwing an exception (fpcalc duration not numeric).

By first parsing the text into a temporary float and then converting into an int, Python correctly handles the decimal portion of the number.